### PR TITLE
fix console output of development server

### DIFF
--- a/functions/server.js
+++ b/functions/server.js
@@ -1,7 +1,8 @@
 const server = require('./src/search').app;
+const port = process.env.PORT || 5000;
 
-server.listen(process.env.PORT || 5000, '0.0.0.0', () => {
-  console.log(`Server is running on http://localhost:5000`);
-  console.log(`- POST: http://localhost:5000/1/apps/`);
-  console.log(`- DELETE: http://localhost:5000/1/apps/:id`);
+server.listen(port, '0.0.0.0', () => {
+  console.log(`Server is running on http://localhost:${port}`);
+  console.log(`- POST: http://localhost:${port}/1/apps/`);
+  console.log(`- DELETE: http://localhost:${port}/1/apps/:id`);
 });


### PR DESCRIPTION
#### Description
The development server reads PORT from process.env, but always logs the default port (5000). This fixes the log output to correctly reflect the configured port.
