### PR TITLE
say it with typescript

### DIFF
--- a/src/app/search-ui/search.service.ts
+++ b/src/app/search-ui/search.service.ts
@@ -9,10 +9,7 @@ import { Observable } from 'rxjs';
 export interface Application {
   category: string;
 
-  /**
-   * From 0 to 5.
-   */
-  rating: number;
+  rating: 0 | 1 | 2 | 3 | 4 | 5;
   name: string;
   image: string;
   link: string;


### PR DESCRIPTION
#### Description
When TypeScript can replace what you'd say in a comment instead: Use union type for small number ranges like ratings.
